### PR TITLE
Bug/ambig parse token

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,13 +2,9 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
-  "python.formatting.provider": "none",
   "python.testing.pytestArgs": ["heimdallm", "-s"],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "editor.rulers": [88],
-  "notebook.formatOnSave.enabled": true,
-  "python.linting.flake8Enabled": false,
-  "python.linting.mypyEnabled": true,
-  "python.linting.enabled": true
+  "notebook.formatOnSave.enabled": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3 - 2/3/24
+
+- Bugfix where elided tree from a boolean token triggered ambiguity resolver
+
 ## 1.0.2 - 11/10/23
 
 - Resolving Dependabot suggestions

--- a/heimdallm/bifrosts/sql/mysql/select/grammar.lark
+++ b/heimdallm/bifrosts/sql/mysql/select/grammar.lark
@@ -114,7 +114,7 @@ between_comparison : value (_WS NOT)? _WS BETWEEN _WS value _WS AND _WS value
 // are declared, so we cannot use this there
 ?value : NUMBER
     | string
-    | boolean
+    | BOOLEAN
     | NULL
     | NUMBER_PREFIX? value_expr
     | NUMBER_PREFIX? fq_column
@@ -135,7 +135,7 @@ function : FUNCTION_NAME "(" \
     ")"
 FUNCTION_NAME : /[a-zA-Z_]+/
 
-?boolean : TRUE | FALSE
+BOOLEAN : TRUE | FALSE
 ?string : ESCAPED_STRING
 
 // a placeholder for a value passed in as a parameter at query execution time

--- a/heimdallm/bifrosts/sql/postgres/select/grammar.lark
+++ b/heimdallm/bifrosts/sql/postgres/select/grammar.lark
@@ -117,7 +117,7 @@ fts_comparison : value "@@" value
 // are declared, so we cannot use this there
 ?value : PREFIX_CAST? (NUMBER
     | string
-    | boolean
+    | BOOLEAN
     | NULL
     | NUMBER_PREFIX? value_expr
     | NUMBER_PREFIX? fq_column
@@ -143,7 +143,7 @@ SUBSTRING_FN_NAME : "substring"i
 EXTRACT_FN_NAME : "extract"i
 CAST_FN_NAME : "cast"i
 
-?boolean : TRUE | FALSE
+BOOLEAN : TRUE | FALSE
 ?string : ESCAPE_PREFIX? ESCAPED_STRING
 
 // a placeholder for a value passed in as a parameter at query execution time

--- a/heimdallm/bifrosts/sql/sqlite/select/grammar.lark
+++ b/heimdallm/bifrosts/sql/sqlite/select/grammar.lark
@@ -117,7 +117,7 @@ between_comparison : value (_WS NOT)? _WS BETWEEN _WS value _WS AND _WS value
 // are declared, so we cannot use this there
 ?value : NUMBER
     | string
-    | boolean
+    | BOOLEAN
     | NULL
     | NUMBER_PREFIX? value_expr
     | NUMBER_PREFIX? fq_column
@@ -136,7 +136,7 @@ function : FUNCTION_NAME "(" \
     ")"
 FUNCTION_NAME : /[a-zA-Z_]+/
 
-?boolean : TRUE | FALSE
+BOOLEAN : TRUE | FALSE
 ?string : ESCAPED_STRING
 
 // a placeholder for a value passed in as a parameter at query execution time

--- a/heimdallm/bifrosts/sql/tests/sql/select/test_ambiguous.py
+++ b/heimdallm/bifrosts/sql/tests/sql/select/test_ambiguous.py
@@ -24,3 +24,20 @@ WHERE
     """
 
     bifrost.traverse(query)
+
+
+@dialects()
+def test_ambiguous_bool(dialect: str, Bifrost: Type[Bifrost]):
+    """A regression test to ensure that boolean tokens do not trigger the ambiguity
+    resolver"""
+    bifrost = Bifrost.validation_only(PermissiveConstraints())
+
+    query = """
+SELECT
+    col
+FROM
+     postings AS p
+WHERE
+     p.is_hired = true
+     """
+    bifrost.traverse(query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "heimdallm"
-version = "1.0.2"
+version = "1.0.3"
 description = "Construct trusted SQL queries from untrusted input"
 homepage = "https://github.com/amoffat/HeimdaLLM"
 repository = "https://github.com/amoffat/HeimdaLLM"


### PR DESCRIPTION
# Description

In the sql select grammars, the boolean value was being treated as an elided tree, instead of a terminal value. Because it was an elided tree, it triggered the ambiguity resolver in some situations. The ambiguity resolver is designed to work on trees, not terminals, but lark was treating the elided tree as a terminal in this situation, causing it to fail.

# Confirmations

These items must be confirmed for your pull request to be accepted. If you cannot accept these items, please explain why and we can try to work out a solution.

## Code quality

Confirm that all of following are true:

- [x] My commits are descriptive and self-contained
- [x] I have written docstrings for any new code
- [x] All non-obvious additions and changes have been clearly commented
- [x] I have added test coverage for any code changes
- [x] I have added or updated the `/docs` where applicable

## Compatibility

Confirm that at least one of the following is true:

- [ ] These changes do not affect any behavior or interfaces (no version change)
- [x] These changes fix intended behavior or interfaces (patch/micro version change)
- [ ] These changes add new behavior or interfaces (minor version change)
- [ ] These changes alter existing behavior or interfaces (major version change)

## Contribution rationale

Confirm that at least one of the following is true:

- [x] This contribution is a bug fix
- [ ] This contribution is a documentation fix
- [ ] This contribution is part of the [public roadmap](https://docs.heimdallm.ai/en/latest/roadmap.html)
- [ ] This contribution was communicated in advance and approved by the author

## Licensing

Confirm that one of the following is true:

- [x] I am contributing as individual and I have signed the [Individual (CLA)](https://forms.gle/sZo4GKdvd8xr27d19)
- [ ] I am contributing on behalf of my employer and have signed the [Corporate CLA](https://forms.gle/6Fa5ULsUbJgTkSXM7)
